### PR TITLE
Switch to System.Text.Json

### DIFF
--- a/JsonFeedNet.Tests/JsonFeedTests.cs
+++ b/JsonFeedNet.Tests/JsonFeedTests.cs
@@ -11,8 +11,9 @@ public class JsonFeedTests
         string inputJsonFeed = TestExtensions.GetResourceAsString("Simple.json").NormalizeEndings();
         JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
         string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
 
-        Assert.Equal(inputJsonFeed, outputJsonFeed);
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -21,8 +22,9 @@ public class JsonFeedTests
         string inputJsonFeed = TestExtensions.GetResourceAsString("DaringFireballBlog.json").NormalizeEndings();
         JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
         string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
-
-        Assert.Equal(inputJsonFeed.Length, outputJsonFeed.Length);
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -31,8 +33,9 @@ public class JsonFeedTests
         string inputJsonFeed = TestExtensions.GetResourceAsString("HyperCriticalBlog.json").NormalizeEndings();
         JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
         string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
-
-        Assert.Equal(inputJsonFeed.Length, outputJsonFeed.Length);
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -41,8 +44,9 @@ public class JsonFeedTests
         string inputJsonFeed = TestExtensions.GetResourceAsString("MaybePizzaBlog.json").NormalizeEndings();
         JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
         string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
-
-        Assert.Equal(inputJsonFeed.Length, outputJsonFeed.Length);
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -51,8 +55,9 @@ public class JsonFeedTests
         string inputJsonFeed = TestExtensions.GetResourceAsString("TheRecordPodcast.json").NormalizeEndings();
         JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
         string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
-
-        Assert.Equal(inputJsonFeed.Length, outputJsonFeed.Length);
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -61,8 +66,9 @@ public class JsonFeedTests
         string inputJsonFeed = TestExtensions.GetResourceAsString("TimeTablePodcast.json").NormalizeEndings();
         JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
         string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
-
-        Assert.Equal(inputJsonFeed.Length, outputJsonFeed.Length);
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -79,8 +85,9 @@ public class JsonFeedTests
         Assert.Single(jsonFeed.Items[0].Authors);
         Assert.Equal("John Gruber", jsonFeed.Items[0].Authors[0].Name);
 
-        Assert.Equal(inputJsonFeed, outputJsonFeed);
-        Assert.Equal(inputJsonFeed.Length, outputJsonFeed.Length);
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -107,8 +114,11 @@ public class JsonFeedTests
         //When
         JsonFeed? jsonFeed = await JsonFeed.ParseFromUriAsync(contentUri, handler);
 
+        string outputJsonFeed = jsonFeed.Write().NormalizeEndings();
+        JsonFeed jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        
         //Then
-        Assert.Equal(inputJsonFeed.NormalizeEndings(), jsonFeed.Write().NormalizeEndings());
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 
     [Fact]
@@ -161,6 +171,7 @@ public class JsonFeedTests
         using StreamReader reader = new(memoryStream);
         string outputJsonFeed = reader.ReadToEnd().NormalizeEndings();
 
-        Assert.Equal(inputJsonFeed, outputJsonFeed);
+        var jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
+        Assert.Equivalent(jsonFeed, jsonFeed2);
     }
 }

--- a/JsonFeedNet/JsonFeedAttachment.cs
+++ b/JsonFeedNet/JsonFeedAttachment.cs
@@ -1,6 +1,6 @@
 ﻿namespace JsonFeedNet;
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 ///     A related resource to a feed.
@@ -10,13 +10,13 @@ public class JsonFeedAttachment
     /// <summary>
     ///     The location of the attachment.
     /// </summary>
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; } //required
 
     /// <summary>
     ///     The mime type of the attachment, such as “audio/mpeg.”
     /// </summary>
-    [JsonProperty("mime_type")]
+    [JsonPropertyName("mime_type")]
     public string MimeType { get; set; } //required
 
     /// <summary>
@@ -25,18 +25,18 @@ public class JsonFeedAttachment
     ///     of the same thing.
     ///     In this way a podcaster, for instance, might provide an audio recording in different formats.
     /// </summary>
-    [JsonProperty("title")]
+    [JsonPropertyName("title")]
     public string Title { get; set; } //optional
 
     /// <summary>
     ///     How large the file is.
     /// </summary>
-    [JsonProperty("size_in_bytes")]
+    [JsonPropertyName("size_in_bytes")]
     public long? SizeInBytes { get; set; } //optional
 
     /// <summary>
     ///     How long the attachment takes to listen to or watch.
     /// </summary>
-    [JsonProperty("duration_in_seconds")]
+    [JsonPropertyName("duration_in_seconds")]
     public long? DurationInSeconds { get; set; } //optional
 }

--- a/JsonFeedNet/JsonFeedAuthor.cs
+++ b/JsonFeedNet/JsonFeedAuthor.cs
@@ -1,6 +1,6 @@
 ﻿namespace JsonFeedNet;
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 ///     A feed author.
@@ -10,14 +10,14 @@ public class JsonFeedAuthor
     /// <summary>
     ///     The author's name.
     /// </summary>
-    [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; } //optional
 
     /// <summary>
     ///     The URL of a site owned by the author.
     ///     It could be a blog, micro-blog, Twitter account, and so on.
     /// </summary>
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; } //optional
 
     /// <summary>
@@ -25,6 +25,6 @@ public class JsonFeedAuthor
     ///     It should be square and relatively large — such as 512 x 512.
     ///     It should use transparency where appropriate, since it may be rendered on a non-white background.
     /// </summary>
-    [JsonProperty("avatar")]
+    [JsonPropertyName("avatar")]
     public string Avatar { get; set; } //optional
 }

--- a/JsonFeedNet/JsonFeedHub.cs
+++ b/JsonFeedNet/JsonFeedHub.cs
@@ -1,6 +1,6 @@
 ﻿namespace JsonFeedNet;
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 ///     Endpoint that can be used to subscribe to real-time notifications of changes to a feed.
@@ -10,12 +10,12 @@ public class JsonFeedHub
     /// <summary>
     ///     The type field describes the protocol used to talk with the hub, such as “rssCloud” or “WebSub.”
     /// </summary>
-    [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public string Type { get; set; } //required
 
     /// <summary>
     ///     Url of the hub endpoint.
     /// </summary>
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; } //required
 }

--- a/JsonFeedNet/JsonFeedItem.cs
+++ b/JsonFeedNet/JsonFeedItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace JsonFeedNet;
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 ///     An individual item in a feed.
@@ -13,40 +13,40 @@ public class JsonFeedItem
     ///     New items should never use a previously-used id.
     ///     Ideally, the id is the full URL of the resource described by the item.
     /// </summary>
-    [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Id { get; set; } //required
 
     /// <summary>
     ///     The URL of the resource described by the feed item.
     ///     This may be the same as the id.
     /// </summary>
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; } //optional
 
     /// <summary>
     ///     The URL of a page elsewhere.
     ///     This is especially useful for link blogs.
     /// </summary>
-    [JsonProperty("external_url")]
+    [JsonPropertyName("external_url")]
     public string ExternalUrl { get; set; } //optional
 
     /// <summary>
     ///     The title of the feed item.
     /// </summary>
-    [JsonProperty("title")]
+    [JsonPropertyName("title")]
     public string Title { get; set; } //optional
 
     /// <summary>
     ///     The content of the feed item formatted as plain HTML.
     ///     This is the only field HTML is allowed in.
     /// </summary>
-    [JsonProperty("content_html")]
+    [JsonPropertyName("content_html")]
     public string ContentHtml { get; set; } //optional
 
     /// <summary>
     ///     The content of the feed item formatted as plain text.
     /// </summary>
-    [JsonProperty("content_text")]
+    [JsonPropertyName("content_text")]
     public string ContentText { get; set; } //optional
 
     /// <summary>
@@ -54,7 +54,7 @@ public class JsonFeedItem
     ///     This might be presented in a timeline, for instance, where a detail view would display all of ContentHtml or
     ///     ContentText.
     /// </summary>
-    [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; } //optional
 
     /// <summary>
@@ -63,7 +63,7 @@ public class JsonFeedItem
     ///     featured image.
     ///     Feed readers may use the image as a preview (probably resized as a thumbnail and placed in a timeline).
     /// </summary>
-    [JsonProperty("image")]
+    [JsonPropertyName("image")]
     public string Image { get; set; } //optional
 
     /// <summary>
@@ -73,29 +73,29 @@ public class JsonFeedItem
     ///     A feed reader with a detail view may choose to show this banner image at the top of the detail view, possibly with
     ///     the title overlaid.
     /// </summary>
-    [JsonProperty("banner_image")]
+    [JsonPropertyName("banner_image")]
     public string BannerImage { get; set; } //optional
 
     /// <summary>
     ///     The date the feed item was published.
     /// </summary>
-    [JsonProperty("date_published")]
+    [JsonPropertyName("date_published")]
     public DateTimeOffset? DatePublished { get; set; } //optional - RFC 3339 format (Example: 2010-02-07T14:04:00-05:00.)
     /// <summary>
     ///     The date the feed item was modified.
     /// </summary>
-    [JsonProperty("date_modified")]
+    [JsonPropertyName("date_modified")]
     public DateTimeOffset? DateModified { get; set; } //optional - RFC 3339 format (Example: 2010-02-07T14:04:00-05:00.)
 
     /// <summary>
     ///     Feed item author.
     ///     If not specified, then the top-level author, if present, is the author of the item.
     /// </summary>
-    [JsonProperty("author")]
+    [JsonPropertyName("author")]
     [Obsolete("obsolete by specification version 1.1. Use `Authors`")]
     public JsonFeedAuthor Author { get; set; } //optional
 
-    [JsonProperty("authors")]
+    [JsonPropertyName("authors")]
     public List<JsonFeedAuthor> Authors { get; set; } //optional
 
     /// <summary>
@@ -103,7 +103,7 @@ public class JsonFeedItem
     ///     Can have any plain text values you want.
     ///     Tags tend to be just one word, but they may be anything.
     /// </summary>
-    [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } //optional
 
     /// <summary>
@@ -111,13 +111,13 @@ public class JsonFeedItem
     ///     The value is usually a 2-letter language tag from ISO 639-1, optionally followed by a region tag.
     ///     (Examples: en or en-US.)
     /// </summary>
-    [JsonProperty("language")]
+    [JsonPropertyName("language")]
     public string Language { get; set; } //optional
 
     /// <summary>
     ///     Related resources for the feed item.
     ///     Podcasts, for instance, would include an attachment that’s an audio or video file.
     /// </summary>
-    [JsonProperty("attachments")]
+    [JsonPropertyName("attachments")]
     public List<JsonFeedAttachment> Attachments { get; set; } //optional
 }

--- a/JsonFeedNet/JsonFeedNet.csproj
+++ b/JsonFeedNet/JsonFeedNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisMode>Recommended</AnalysisMode>
@@ -18,15 +18,17 @@
     <PackageProjectUrl>https://github.com/DanRigby/JsonFeed.Net</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-      Added .NET7.0 target and removed .NET5.0 target.
+      Added .NET8.0 target and removed .NET7.0 target.
+      Support NativeAOT/Trimming with JSON Source Generation.
     </PackageReleaseNotes>
     <PackageTags>jsonfeed jsonfeed.net jsonfeed.org</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonFeedNet/SourceGenerationContext.cs
+++ b/JsonFeedNet/SourceGenerationContext.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace JsonFeedNet;
+
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull | JsonIgnoreCondition.WhenWritingDefault)]
+[JsonSerializable(typeof(JsonFeed))]
+[JsonSerializable(typeof(JsonFeedAttachment))]
+[JsonSerializable(typeof(JsonFeedAuthor))]
+[JsonSerializable(typeof(JsonFeedHub))]
+[JsonSerializable(typeof(JsonFeedItem))]
+internal partial class SourceGenerationContext : JsonSerializerContext
+{
+}


### PR DESCRIPTION
This pull request makes several changes to allow supporting NativeAOT and trimming.

- Remove Newtonsoft.JSON and replace it with the build-in System.Text.Json
- Use JsonSourceGeneration to handle serialization/deserialization
Remove the netcore3.0 and net7.0 targets, as they are both unsupported runtimes. Netstandard2.0 should be able to cover those runtimes if someone still uses them.
- Update the tests to reflect switching to System.Text.Json

System.Text.Json makes changes to how it handles [encoding Unicode values](https://github.com/dotnet/runtime/issues/94135) that would break trying to directly compare the literal strings between the input and output, even though when read back into a JSON Parser, it will read fine. So I changed the tests to compare the objects when reparsed rather than compare the strings, as they would require relaxing encoding checks. Even if the literal strings are not the same, they represent the same values in a safe way that should work cross-platform.