### PR TITLE
Add support for custom objects and fields

### DIFF
--- a/JsonFeedNet.Tests/JsonFeedTests.cs
+++ b/JsonFeedNet.Tests/JsonFeedTests.cs
@@ -174,4 +174,19 @@ public class JsonFeedTests
         var jsonFeed2 = JsonFeed.Parse(outputJsonFeed);
         Assert.Equivalent(jsonFeed, jsonFeed2);
     }
+
+    [Fact]
+    public void CustomObjectsHandling()
+    {
+        string inputJsonFeed = TestExtensions.GetResourceAsString("Simple.json").NormalizeEndings();
+        JsonFeed jsonFeed = JsonFeed.Parse(inputJsonFeed);
+
+        Assert.True(jsonFeed.CustomObjects.ContainsKey("_custom_feed_object"));
+        Assert.Equal("custom_feed_value1", jsonFeed.CustomObjects["_custom_feed_object"].GetProperty("custom_feed_key1").GetString());
+        Assert.Equal("custom_feed_value2", jsonFeed.CustomObjects["_custom_feed_object"].GetProperty("custom_feed_key2").GetString());
+
+        Assert.True(jsonFeed.Items[0].CustomObjects.ContainsKey("_custom_object"));
+        Assert.Equal("custom_value1", jsonFeed.Items[0].CustomObjects["_custom_object"].GetProperty("custom_key1").GetString());
+        Assert.Equal("custom_value2", jsonFeed.Items[0].CustomObjects["_custom_object"].GetProperty("custom_key2").GetString());
+    }
 }

--- a/JsonFeedNet.Tests/Resources/Simple.json
+++ b/JsonFeedNet.Tests/Resources/Simple.json
@@ -7,12 +7,20 @@
     {
       "id": "2",
       "url": "https://example.org/second-item",
-      "content_text": "This is a second item."
+      "content_text": "This is a second item.",
+      "_custom_object": {
+        "custom_key1": "custom_value1",
+        "custom_key2": "custom_value2"
+      }
     },
     {
       "id": "1",
       "url": "https://example.org/initial-post",
       "content_html": "<p>Hello, world!</p>"
     }
-  ]
+  ],
+  "_custom_feed_object": {
+    "custom_feed_key1": "custom_feed_value1",
+    "custom_feed_key2": "custom_feed_value2"
+  }
 }

--- a/JsonFeedNet/JsonFeed.cs
+++ b/JsonFeedNet/JsonFeed.cs
@@ -120,6 +120,12 @@ public class JsonFeed
     public List<JsonFeedItem> Items { get; set; } //required
 
     /// <summary>
+    ///     Custom objects in the feed.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> CustomObjects { get; set; } = new(); //optional
+
+    /// <summary>
     ///     Parses a JsonFeed in an input string into a JsonFeed object for use by code.
     /// </summary>
     /// <param name="jsonFeedString">The JSON Feed as a string.</param>

--- a/JsonFeedNet/JsonFeedItem.cs
+++ b/JsonFeedNet/JsonFeedItem.cs
@@ -1,5 +1,6 @@
 ﻿namespace JsonFeedNet;
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -124,4 +125,10 @@ public class JsonFeedItem
     /// </summary>
     [JsonPropertyName("attachments")]
     public List<JsonFeedAttachment> Attachments { get; set; } //optional
+
+    /// <summary>
+    ///     Custom objects in the feed item.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> CustomObjects { get; set; } = new(); //optional
 }


### PR DESCRIPTION
Fixes #1

Add support for custom objects and fields in JSON feeds.

* Add `CustomObjects` property to `JsonFeed` and `JsonFeedItem` classes to store custom objects.
* Update `Simple.json` test resource to include examples of custom objects with names starting with an underscore and alphanumeric member keys.
* Add test in `JsonFeedTests.cs` to verify the handling of custom objects in the feed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DanRigby/JsonFeed.NET/issues/1?shareId=3416ddab-4726-444f-936b-182672f67676).