### PR TITLE
Update build.yml to only install .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,7 @@ jobs:
     - name: Setup DotNet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-          6.x
-          8.x
+        dotnet-version: 8.x
 
     - name: Restore Tools
       run: dotnet tool restore


### PR DESCRIPTION
NVika has been updated to target .NET 8, so we don't need to side by side install .NET 6 anymore.