### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/DanRigby/JsonFeed.NET/security/code-scanning/62](https://github.com/DanRigby/JsonFeed.NET/security/code-scanning/62)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (e.g., to check out code and run tests), the `contents: read` permission is sufficient. This change ensures the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
